### PR TITLE
feat: add translation strings for orderStatusThankYouPage

### DIFF
--- a/blink-for-woocommerce.php
+++ b/blink-for-woocommerce.php
@@ -222,20 +222,20 @@ class BlinkWCPlugin {
 
     switch ($status) {
       case 'pending':
-        $statusDesc = 'Waiting payment';
+        $statusDesc = __( 'Waiting payment', 'blink-for-woocommerce' );
         break;
       case 'on-hold':
-        $statusDesc = 'Waiting for payment settlement';
+        $statusDesc = __( 'Waiting for payment settlement', 'blink-for-woocommerce' );
         break;
       case 'processing':
-        $statusDesc = 'Payment settled';
+        $statusDesc = __( 'Payment settled', 'blink-for-woocommerce' );
         break;
       case 'completed':
-        $statusDesc = 'Order completed';
+        $statusDesc = __( 'Order completed', 'blink-for-woocommerce' );
         break;
       case 'failed':
       case 'cancelled':
-        $statusDesc = 'Payment failed';
+        $statusDesc = __( 'Payment failed', 'blink-for-woocommerce' );
         break;
       default:
         $statusDesc = ucfirst($status);
@@ -244,7 +244,7 @@ class BlinkWCPlugin {
 
     echo "
       <section class='woocommerce-order-payment-status'>
-          <h2 class='woocommerce-order-payment-status-title'>Order Status</h2>
+          <h2 class='woocommerce-order-payment-status-title'>".__( 'Order Status', 'blink-for-woocommerce' )."</h2>
           <p><strong>" .
       esc_html($statusDesc) .
       "</strong></p>

--- a/languages/blink-for-woocommerce.pot
+++ b/languages/blink-for-woocommerce.pot
@@ -1,49 +1,64 @@
-# Copyright (C) 2024 Blink
-# This file is distributed under the MIT.
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Blink For Woocommerce 0.1.3\n"
-"Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/blink-for-woocommerce\n"
-"POT-Creation-Date: 2024-11-29 15:09:11+00:00\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
+"Project-Id-Version: Blink For Woocommerce\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-21 19:52+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: en\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Country: United States\n"
-"X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: "
-"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
-"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
-"X-Poedit-Basepath: ../\n"
-"X-Poedit-SearchPath-0: .\n"
-"X-Poedit-Bookmarks: \n"
-"X-Textdomain-Support: yes\n"
-"X-Generator: grunt-wp-i18n 1.0.3\n"
+"Language-Team: \n"
+"Language: \n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Loco https://localise.biz/\n"
+"X-Loco-Version: 2.8.0; wp-6.8.2; php-8.3.13\n"
+"X-Domain: blink-for-woocommerce"
 
-#. Plugin Name of the plugin/theme
+#. Author of the plugin
+msgid "Blink"
+msgstr ""
+
+#. Name of the plugin
 msgid "Blink For Woocommerce"
 msgstr ""
 
-#. Plugin URI of the plugin/theme
-msgid "https://wordpress.org/plugins/blink-for-woocommerce/"
-msgstr ""
-
-#. Description of the plugin/theme
+#. Description of the plugin
 msgid ""
 "Blink is a free and open-source bitcoin wallet which allows you to receive "
 "payments in Bitcoin and stablesats directly, with no fees or transaction "
 "cost."
 msgstr ""
 
-#. Author of the plugin/theme
-msgid "Blink"
+#. Author URI of the plugin
+msgid "https://blink.sv"
 msgstr ""
 
-#. Author URI of the plugin/theme
-msgid "https://blink.sv"
+#. URI of the plugin
+msgid "https://wordpress.org/plugins/blink-for-woocommerce/"
+msgstr ""
+
+#: blink-for-woocommerce.php:234
+msgid "Order completed"
+msgstr ""
+
+#: blink-for-woocommerce.php:247
+msgid "Order Status"
+msgstr ""
+
+#: blink-for-woocommerce.php:238
+msgid "Payment failed"
+msgstr ""
+
+#: blink-for-woocommerce.php:231
+msgid "Payment settled"
+msgstr ""
+
+#: blink-for-woocommerce.php:228
+msgid "Waiting for payment settlement"
+msgstr ""
+
+#: blink-for-woocommerce.php:225
+msgid "Waiting payment"
 msgstr ""


### PR DESCRIPTION
This PR adds translation strings to the orderStatusThankYouPage.
Users may add their own translations in any language through [Loco Translate Plugin](https://wordpress.org/plugins/loco-translate/).

.pot has been updated running:

```bash
docker compose exec -it wordpress wp loco extract plugins --allow-root
```
