### PR TITLE
feat: add non-custodial lightning address support

### DIFF
--- a/assets/css/pay.css
+++ b/assets/css/pay.css
@@ -1,0 +1,56 @@
+.blink-pay-container {
+  max-width: 420px;
+  margin: 2em auto;
+  padding: 2em 1.5em;
+  text-align: center;
+  border: 1px solid #e2e4e7;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  background: #fff;
+}
+
+.blink-pay-container h2 {
+  margin-top: 0;
+  font-size: 1.25em;
+}
+
+.blink-pay-amount {
+  font-size: 1.5em;
+  font-weight: 700;
+  margin: 0.25em 0 1em;
+}
+
+.blink-pay-qr {
+  display: inline-block;
+  max-width: 260px;
+  width: 100%;
+  margin: 0 auto 1em;
+}
+
+.blink-pay-qr svg {
+  width: 100%;
+  height: auto;
+}
+
+.blink-pay-invoice code {
+  display: block;
+  word-break: break-all;
+  padding: 0.75em;
+  background: #f6f7f7;
+  border-radius: 6px;
+  font-size: 0.75em;
+  color: #50575e;
+}
+
+.blink-pay-actions {
+  display: flex;
+  gap: 0.5em;
+  justify-content: center;
+  margin: 1em 0;
+}
+
+.blink-pay-status {
+  margin-top: 1em;
+  font-weight: 600;
+  color: #50575e;
+}

--- a/assets/js/frontend/pay.js
+++ b/assets/js/frontend/pay.js
@@ -69,7 +69,22 @@
     }
   }
 
+  function pastDeadline() {
+    return (
+      typeof BlinkPay.deadline === 'number' &&
+      BlinkPay.deadline > 0 &&
+      Date.now() / 1000 > BlinkPay.deadline
+    );
+  }
+
   function poll() {
+    // Absolute timeout: stop polling once the invoice deadline has passed so the
+    // browser never polls forever (e.g. verify endpoint permanently unreachable).
+    if (pastDeadline()) {
+      setStatus('This invoice has expired. Please place the order again.');
+      return;
+    }
+
     var body = new URLSearchParams();
     body.append('action', 'blink_check_invoice');
     body.append('nonce', BlinkPay.nonce);

--- a/assets/js/frontend/pay.js
+++ b/assets/js/frontend/pay.js
@@ -1,0 +1,113 @@
+/* global BlinkPay, qrcode */
+(function () {
+  'use strict';
+
+  if (typeof BlinkPay === 'undefined') {
+    return;
+  }
+
+  function renderQr() {
+    var container = document.getElementById('blink-pay-qr');
+    if (!container || typeof qrcode === 'undefined') {
+      return;
+    }
+
+    var data = container.getAttribute('data-uri') || BlinkPay.lightningUri;
+    if (!data) {
+      return;
+    }
+
+    try {
+      // Type 0 = auto-detect the smallest fitting version. 'M' error correction.
+      var qr = qrcode(0, 'M');
+      qr.addData(data);
+      qr.make();
+      container.innerHTML = qr.createSvgTag({ cellSize: 4, margin: 4, scalable: true });
+    } catch (e) {
+      // If the payload is too large for the default type, retry with high capacity.
+      try {
+        var qrBig = qrcode(0, 'L');
+        qrBig.addData(data);
+        qrBig.make();
+        container.innerHTML = qrBig.createSvgTag({ cellSize: 4, margin: 4 });
+      } catch (err) {
+        container.textContent = data;
+      }
+    }
+  }
+
+  function setupCopy() {
+    var button = document.getElementById('blink-pay-copy');
+    if (!button) {
+      return;
+    }
+    button.addEventListener('click', function () {
+      var text = BlinkPay.paymentRequest || '';
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () {
+          button.textContent = 'Copied!';
+          setTimeout(function () {
+            button.textContent = 'Copy invoice';
+          }, 2000);
+        });
+      } else {
+        var el = document.getElementById('blink-pay-bolt11');
+        if (el) {
+          var range = document.createRange();
+          range.selectNode(el);
+          window.getSelection().removeAllRanges();
+          window.getSelection().addRange(range);
+        }
+      }
+    });
+  }
+
+  function setStatus(message) {
+    var el = document.getElementById('blink-pay-status');
+    if (el) {
+      el.textContent = message;
+    }
+  }
+
+  function poll() {
+    var body = new URLSearchParams();
+    body.append('action', 'blink_check_invoice');
+    body.append('nonce', BlinkPay.nonce);
+    body.append('order_id', BlinkPay.orderId);
+    body.append('order_key', BlinkPay.orderKey);
+
+    fetch(BlinkPay.ajaxUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      credentials: 'same-origin',
+    })
+      .then(function (res) {
+        return res.json();
+      })
+      .then(function (json) {
+        if (json && json.success && json.data) {
+          if (json.data.status === 'PAID' && json.data.redirect) {
+            setStatus('Payment received! Redirecting…');
+            window.location.href = json.data.redirect;
+            return;
+          }
+          if (json.data.status === 'EXPIRED') {
+            setStatus('This invoice has expired. Please place the order again.');
+            return;
+          }
+        }
+        window.setTimeout(poll, BlinkPay.pollInterval || 3000);
+      })
+      .catch(function () {
+        // Transient error: keep polling.
+        window.setTimeout(poll, BlinkPay.pollInterval || 3000);
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    renderQr();
+    setupCopy();
+    window.setTimeout(poll, BlinkPay.pollInterval || 3000);
+  });
+})();

--- a/assets/js/frontend/qrcode.min.js
+++ b/assets/js/frontend/qrcode.min.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));

--- a/blink-for-woocommerce.php
+++ b/blink-for-woocommerce.php
@@ -9,7 +9,7 @@
  * License URI:     https://github.com/blinkbitcoin/blink-for-woocommerce/blob/main/license.txt
  * Text Domain:     blink-for-woocommerce
  * Domain Path:     /languages
- * Version:         0.1.3
+ * Version:         0.2.1
  *
  * @package         Blink_For_Woocommerce
  */
@@ -19,7 +19,7 @@ use Blink\WC\Helpers\Logger;
 use Blink\WC\Gateway\BlinkLnGateway;
 
 defined('ABSPATH') || exit();
-define('BLINK_VERSION', '0.1.3');
+define('BLINK_VERSION', '0.2.1');
 define('BLINK_VERSION_KEY', 'blink_version');
 define('BLINK_PLUGIN_FILE_PATH', plugin_dir_path(__FILE__));
 define('BLINK_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -50,6 +50,27 @@ class BlinkWCPlugin {
 
         return $settings;
       });
+
+      // Register the custom settings-field renderers exactly once per request.
+      // These must NOT live in GlobalSettings::__construct(), because WooCommerce
+      // instantiates the settings page multiple times per request (via the
+      // woocommerce_get_settings_pages filter). Registering there would attach a
+      // distinct per-instance callback each time. Using a static callback also lets
+      // WordPress de-duplicate the registration.
+      //
+      // The field type is namespaced as "blink_custom_markup" (not the generic
+      // "custom_markup") to avoid colliding with other active plugins that use the
+      // same generic type/hook (e.g. the BTCPay for WooCommerce plugin). A shared
+      // hook name would cause every plugin's renderer to fire for every plugin's
+      // fields, rendering each custom row once per registered renderer.
+      add_action('woocommerce_admin_field_blink_custom_markup', [
+        '\Blink\WC\Admin\GlobalSettings',
+        'output_custom_markup_field',
+      ]);
+      add_action('woocommerce_admin_field_order_states', [
+        new \Blink\WC\Helpers\OrderStates(),
+        'renderOrderStatesHtml',
+      ]);
 
       $this->dependenciesNotification();
       $this->notConfiguredNotification();

--- a/blink-for-woocommerce.php
+++ b/blink-for-woocommerce.php
@@ -9,7 +9,7 @@
  * License URI:     https://github.com/blinkbitcoin/blink-for-woocommerce/blob/main/license.txt
  * Text Domain:     blink-for-woocommerce
  * Domain Path:     /languages
- * Version:         0.2.1
+ * Version:         0.2.2
  *
  * @package         Blink_For_Woocommerce
  */
@@ -19,7 +19,7 @@ use Blink\WC\Helpers\Logger;
 use Blink\WC\Gateway\BlinkLnGateway;
 
 defined('ABSPATH') || exit();
-define('BLINK_VERSION', '0.2.1');
+define('BLINK_VERSION', '0.2.2');
 define('BLINK_VERSION_KEY', 'blink_version');
 define('BLINK_PLUGIN_FILE_PATH', plugin_dir_path(__FILE__));
 define('BLINK_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+= 0.2.1 :: 2026-07-10 =
+* Fix duplicate custom rows (Webhook Url, Setup status) on the Blink settings page
+* Light visual cleanup of the non-custodial on-site pay page
+* Clarify that the custodial Blink dashboard callback endpoint must be enabled
+
+= 0.2.0 :: 2026-07-09 =
+* Add support for non-custodial Blink accounts via lightning address (LNURL-pay + LUD-21 verify)
+* Add "Account Type" setting to choose between custodial (API key) and non-custodial (lightning address)
+* Render Lightning invoice with QR code on an on-site pay page for non-custodial orders
+* Detect settlement for non-custodial orders by polling the LUD-21 verify endpoint
+
 = 0.1.3 :: 2024-11-29 =
 * Update PHP min version
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 0.2.2 :: 2026-07-10 =
+* Security: validate LNURL callback/verify URLs (same domain + no private/loopback IPs) and disable redirects to prevent SSRF
+* Honor the server-advertised LUD-12 commentAllowed limit when creating non-custodial invoices
+* Recreate expired non-custodial invoices on checkout retry instead of reusing an unpayable one
+* Rate limit the public settlement-poll AJAX endpoint
+* Add an absolute client-side polling timeout on the pay page
+* Validate the account type setting against the allowed values
+
 = 0.2.1 :: 2026-07-10 =
 * Fix duplicate custom rows (Webhook Url, Setup status) on the Blink settings page
 * Light visual cleanup of the non-custodial on-site pay page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blink-for-woocommerce",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blink-for-woocommerce",
-      "version": "0.1.2",
+      "version": "0.2.1",
       "devDependencies": {
         "@prettier/plugin-php": "^0.22.2",
         "grunt": "^1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blink-for-woocommerce",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blink-for-woocommerce",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "devDependencies": {
         "@prettier/plugin-php": "^0.22.2",
         "grunt": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-for-woocommerce",
-  "version": "0.1.3",
+  "version": "0.2.1",
   "main": "Gruntfile.js",
   "author": "Blink",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-for-woocommerce",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "Gruntfile.js",
   "author": "Blink",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Bitcoin, Lightning Network, WooCommerce, payment gateway
 Requires at least: 4.5
 Tested up to: 6.6.1
 Requires PHP: 8.1
-Stable tag: 0.2.1
+Stable tag: 0.2.2
 License: MIT
 License URI: https://github.com/blinkbitcoin/blink-for-woocommerce/blob/main/license.txt
 
@@ -71,6 +71,14 @@ Yes, visit the [Blink website](https://www.blink.sv/) for support and troublesho
 2. Payment Checkout Page - Customers can choose to pay with Bitcoin via the Lightning Network during checkout.
 
 == Changelog ==
+
+= 0.2.2 =
+* Security: validate LNURL callback/verify URLs (same domain + no private/loopback IPs) and disable redirects to prevent SSRF
+* Honor the server-advertised LUD-12 commentAllowed limit when creating non-custodial invoices
+* Recreate expired non-custodial invoices on checkout retry instead of reusing an unpayable one
+* Rate limit the public settlement-poll AJAX endpoint
+* Add an absolute client-side polling timeout on the pay page
+* Validate the account type setting against the allowed values
 
 = 0.2.1 =
 * Fix duplicate custom rows (Webhook Url, Setup status) on the Blink settings page

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Bitcoin, Lightning Network, WooCommerce, payment gateway
 Requires at least: 4.5
 Tested up to: 6.6.1
 Requires PHP: 8.1
-Stable tag: 0.1.3
+Stable tag: 0.2.1
 License: MIT
 License URI: https://github.com/blinkbitcoin/blink-for-woocommerce/blob/main/license.txt
 
@@ -20,6 +20,7 @@ Key features of Blink For WooCommerce include:
 * Low Transaction Fees: Enjoy significantly lower transaction fees compared to traditional payment methods, helping you save on processing costs.
 * Stablesats Integration: Offers the ability to receive payments in Bitcoin while maintaining a stable value pegged to the US Dollar, reducing volatility risks.
 * Easy Integration: Simple setup and configuration within WooCommerce, allowing you to start accepting Bitcoin payments quickly and easily.
+* Custodial or Non-custodial: Connect a custodial Blink account with an API key, or a non-custodial (self-custodial) account using just your Blink lightning address. Non-custodial payments are shown as a Lightning QR code on your store and require no API key.
 
 For more information please visit [Plugin Repository](https://github.com/blinkbitcoin/blink-for-woocommerce/).
 
@@ -70,6 +71,17 @@ Yes, visit the [Blink website](https://www.blink.sv/) for support and troublesho
 2. Payment Checkout Page - Customers can choose to pay with Bitcoin via the Lightning Network during checkout.
 
 == Changelog ==
+
+= 0.2.1 =
+* Fix duplicate custom rows (Webhook Url, Setup status) on the Blink settings page
+* Light visual cleanup of the non-custodial on-site pay page
+* Clarify that the custodial Blink dashboard callback endpoint must be enabled
+
+= 0.2.0 =
+* Add support for non-custodial Blink accounts via lightning address (LNURL-pay + LUD-21 verify)
+* Add "Account Type" setting to choose between custodial (API key) and non-custodial (lightning address)
+* Render Lightning invoice with QR code on an on-site pay page for non-custodial orders
+* Detect settlement for non-custodial orders by polling the LUD-21 verify endpoint
 
 = 0.1.3 =
 * Update PHP min version

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -220,6 +220,10 @@ class GlobalSettings extends \WC_Settings_Page {
     $accountType = !empty($_POST['blink_account_type'])
       ? sanitize_text_field(wp_unslash($_POST['blink_account_type']))
       : 'custodial';
+    // Constrain to the known set so an unexpected value cannot be persisted.
+    if (!in_array($accountType, ['custodial', 'non_custodial'], true)) {
+      $accountType = 'custodial';
+    }
 
     if ($accountType === 'non_custodial') {
       if (!empty($_POST['blink_ln_address'])) {

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -74,10 +74,12 @@ class GlobalSettings extends \WC_Settings_Page {
       $setupStatus = '<p class="blink-connection-error">
           Not connected. Please configure your api key.
         </p>';
-      if ($storedBlinkEnv && $storedApiKey) {
-        if (BlinkApiHelper::verifyApiKey($storedBlinkEnv, $storedApiKey)) {
-          $setupStatus = '<p class="blink-connection-success">Connected.</p>';
-        }
+      if (
+        $storedBlinkEnv &&
+        $storedApiKey &&
+        BlinkApiHelper::verifyApiKey($storedBlinkEnv, $storedApiKey)
+      ) {
+        $setupStatus = '<p class="blink-connection-success">Connected.</p>';
       }
     }
 

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -54,34 +54,39 @@ class GlobalSettings extends \WC_Settings_Page {
     return $this->getGlobalSettings();
   }
 
+  private function connectedMarkup(): string {
+    return '<p class="blink-connection-success">Connected.</p>';
+  }
+
+  private function notConnectedMarkup(string $message): string {
+    return '<p class="blink-connection-error">' . $message . '</p>';
+  }
+
+  private function getSetupStatusMarkup(): string {
+    $accountType = get_option('blink_account_type', 'custodial');
+
+    if ($accountType === 'non_custodial') {
+      $lnAddress = get_option('blink_ln_address');
+      if ($lnAddress && BlinkApiHelper::verifyLnAddress($lnAddress)) {
+        return $this->connectedMarkup();
+      }
+      return $this->notConnectedMarkup(
+        'Not connected. Please configure your Blink lightning address.'
+      );
+    }
+
+    $env = get_option('blink_env');
+    $apiKey = get_option('blink_api_key');
+    if ($env && $apiKey && BlinkApiHelper::verifyApiKey($env, $apiKey)) {
+      return $this->connectedMarkup();
+    }
+    return $this->notConnectedMarkup('Not connected. Please configure your api key.');
+  }
+
   public function getGlobalSettings(): array {
     Logger::debug('Entering Global Settings form.');
 
-    // Check setup status and prepare output.
-    $storedApiKey = get_option('blink_api_key');
-    $storedBlinkEnv = get_option('blink_env');
-    $storedAccountType = get_option('blink_account_type', 'custodial');
-    $storedLnAddress = get_option('blink_ln_address');
-
-    if ($storedAccountType === 'non_custodial') {
-      $setupStatus = '<p class="blink-connection-error">
-          Not connected. Please configure your Blink lightning address.
-        </p>';
-      if ($storedLnAddress && BlinkApiHelper::verifyLnAddress($storedLnAddress)) {
-        $setupStatus = '<p class="blink-connection-success">Connected.</p>';
-      }
-    } else {
-      $setupStatus = '<p class="blink-connection-error">
-          Not connected. Please configure your api key.
-        </p>';
-      if (
-        $storedBlinkEnv &&
-        $storedApiKey &&
-        BlinkApiHelper::verifyApiKey($storedBlinkEnv, $storedApiKey)
-      ) {
-        $setupStatus = '<p class="blink-connection-success">Connected.</p>';
-      }
-    }
+    $setupStatus = $this->getSetupStatusMarkup();
 
     return [
       // Section connection.
@@ -212,13 +217,12 @@ class GlobalSettings extends \WC_Settings_Page {
   }
 
   /**
-   * On saving the settings form make sure to check if the API key works and register a webhook if needed.
+   * On saving the settings form make sure the configured account works.
    */
   public function save() {
-    // If we have url, storeID and apiKey we want to check if the api key works and register a webhook.
     Logger::debug('Saving GlobalSettings.');
 
-    // nonce validation is not required here because it is done by parent::save()
+    // Nonce validation is handled by parent::save().
     $accountType = !empty($_POST['blink_account_type'])
       ? sanitize_text_field(wp_unslash($_POST['blink_account_type']))
       : 'custodial';
@@ -228,49 +232,63 @@ class GlobalSettings extends \WC_Settings_Page {
     }
 
     if ($accountType === 'non_custodial') {
-      if (!empty($_POST['blink_ln_address'])) {
-        $lnAddress = sanitize_text_field(wp_unslash($_POST['blink_ln_address']));
-
-        if (!BlinkApiHelper::verifyLnAddress($lnAddress)) {
-          $messageException =
-            'Could not verify this Blink lightning address. Please check that it is valid and reachable (format: yourname@blink.sv).';
-          Notice::addNotice('error', $messageException);
-          Logger::debug($messageException, true);
-        }
-      } else {
-        $messageNotConnecting =
-          'Did not try to connect because the Blink lightning address is missing.';
-        Notice::addNotice('warning', $messageNotConnecting);
-        Logger::debug($messageNotConnecting);
-      }
-    } elseif (!empty($_POST['blink_env']) && !empty($_POST['blink_api_key'])) {
-      $apiEnv = sanitize_text_field(wp_unslash($_POST['blink_env']));
-      $apiKey = sanitize_text_field(wp_unslash($_POST['blink_api_key']));
-
-      if (!BlinkApiHelper::verifyApiKey($apiEnv, $apiKey)) {
-        $messageException =
-          'Error fetching data for this API key from server. Please check if the API key is valid.';
-        Notice::addNotice('error', $messageException);
-        Logger::debug($messageException, true);
-      }
-    } else {
-      $messageNotConnecting =
-        'Did not try to connect to Blink API because one of the required information was missing: Environment or api key';
-      Notice::addNotice('warning', $messageNotConnecting);
-      Logger::debug($messageNotConnecting);
+      $this->validateNonCustodialOnSave();
+    }
+    if ($accountType === 'custodial') {
+      $this->validateCustodialOnSave();
     }
 
     parent::save();
   }
 
-  public static function output_custom_markup_field($value) {
-    echo '<tr valign="top">';
-    if (!empty($value['title'])) {
-      echo '<th scope="row" class="titledesc">' . esc_html($value['title']) . '</th>';
-    } else {
-      echo '<th scope="row" class="titledesc">&nbsp;</th>';
+  private function validateNonCustodialOnSave(): void {
+    if (empty($_POST['blink_ln_address'])) {
+      $message = 'Did not try to connect because the Blink lightning address is missing.';
+      Notice::addNotice('warning', $message);
+      Logger::debug($message);
+      return;
     }
 
+    $lnAddress = sanitize_text_field(wp_unslash($_POST['blink_ln_address']));
+    if (BlinkApiHelper::verifyLnAddress($lnAddress)) {
+      return;
+    }
+
+    $message =
+      'Could not verify this Blink lightning address. Please check that it is valid and reachable (format: yourname@blink.sv).';
+    Notice::addNotice('error', $message);
+    Logger::debug($message, true);
+  }
+
+  private function validateCustodialOnSave(): void {
+    if (empty($_POST['blink_env']) || empty($_POST['blink_api_key'])) {
+      $message =
+        'Did not try to connect to Blink API because one of the required information was missing: Environment or api key';
+      Notice::addNotice('warning', $message);
+      Logger::debug($message);
+      return;
+    }
+
+    $apiEnv = sanitize_text_field(wp_unslash($_POST['blink_env']));
+    $apiKey = sanitize_text_field(wp_unslash($_POST['blink_api_key']));
+    if (BlinkApiHelper::verifyApiKey($apiEnv, $apiKey)) {
+      return;
+    }
+
+    $message =
+      'Error fetching data for this API key from server. Please check if the API key is valid.';
+    Notice::addNotice('error', $message);
+    Logger::debug($message, true);
+  }
+
+  public static function output_custom_markup_field($value) {
+    $title = '&nbsp;';
+    if (!empty($value['title'])) {
+      $title = esc_html($value['title']);
+    }
+
+    echo '<tr valign="top">';
+    echo '<th scope="row" class="titledesc">' . $title . '</th>';
     echo '<td class="forminp" id="' . esc_attr($value['id']) . '">';
     echo wp_kses_post($value['markup']);
     echo '</td>';

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -16,15 +16,13 @@ class GlobalSettings extends \WC_Settings_Page {
     $this->label = 'Blink Settings';
     $this->apiHelper = new BlinkApiHelper();
 
-    // Register custom field type order_states with OrderStatesField class.
-    add_action('woocommerce_admin_field_order_states', [
-      new OrderStates(),
-      'renderOrderStatesHtml',
-    ]);
-    add_action('woocommerce_admin_field_custom_markup', [
-      $this,
-      'output_custom_markup_field',
-    ]);
+    // NOTE: The custom field renderers (order_states, blink_custom_markup) are
+    // registered once in the plugin bootstrap (blink-for-woocommerce.php), NOT here.
+    // WooCommerce instantiates the settings page multiple times per request via the
+    // woocommerce_get_settings_pages filter; registering the render callbacks in this
+    // constructor would attach a distinct per-instance callback each time. The
+    // "blink_custom_markup" type is namespaced to avoid colliding with other plugins
+    // (e.g. BTCPay for WooCommerce) that use a generic "custom_markup" type/hook.
 
     if (is_admin()) {
       // Register and include JS.
@@ -62,13 +60,24 @@ class GlobalSettings extends \WC_Settings_Page {
     // Check setup status and prepare output.
     $storedApiKey = get_option('blink_api_key');
     $storedBlinkEnv = get_option('blink_env');
+    $storedAccountType = get_option('blink_account_type', 'custodial');
+    $storedLnAddress = get_option('blink_ln_address');
 
-    $setupStatus = '<p class="blink-connection-error">
-        Not connected. Please configure your api key.
-      </p>';
-    if ($storedBlinkEnv && $storedApiKey) {
-      if (BlinkApiHelper::verifyApiKey($storedBlinkEnv, $storedApiKey)) {
+    if ($storedAccountType === 'non_custodial') {
+      $setupStatus = '<p class="blink-connection-error">
+          Not connected. Please configure your Blink lightning address.
+        </p>';
+      if ($storedLnAddress && BlinkApiHelper::verifyLnAddress($storedLnAddress)) {
         $setupStatus = '<p class="blink-connection-success">Connected.</p>';
+      }
+    } else {
+      $setupStatus = '<p class="blink-connection-error">
+          Not connected. Please configure your api key.
+        </p>';
+      if ($storedBlinkEnv && $storedApiKey) {
+        if (BlinkApiHelper::verifyApiKey($storedBlinkEnv, $storedApiKey)) {
+          $setupStatus = '<p class="blink-connection-success">Connected.</p>';
+        }
       }
     }
 
@@ -83,6 +92,19 @@ class GlobalSettings extends \WC_Settings_Page {
           PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION
         ),
         'id' => 'blink_connection',
+      ],
+      'blink_account_type' => [
+        'title' => 'Account Type',
+        'type' => 'select',
+        'options' => [
+          'custodial' => 'Custodial (API key)',
+          'non_custodial' => 'Non-custodial (Lightning address)',
+        ],
+        'default' => 'custodial',
+        'desc' =>
+          'Custodial uses a Blink API key. Non-custodial uses your Blink lightning address (self-custody) and does not require an API key or a Blink dashboard webhook.',
+        'desc_tip' => true,
+        'id' => 'blink_account_type',
       ],
       'blink_env' => [
         'title' => 'Blink Environment',
@@ -112,21 +134,30 @@ class GlobalSettings extends \WC_Settings_Page {
         'title' => 'Blink API Key',
         'type' => 'text',
         'desc' =>
-          'Your Blink API Key. If you do not have any yet use <a target="_blank" href="https://dashboard.blink.sv/api-keys">Blink dashboard</a> to get a new one.<br />IMPORTANT: Create an API key with only READ & RECEIVE scopes. <br />⚠️ Using an API key with WRITE scope could result in loss of funds ⚠️',
+          'Your Blink API Key (custodial account type only). If you do not have any yet use <a target="_blank" href="https://dashboard.blink.sv/api-keys">Blink dashboard</a> to get a new one.<br />IMPORTANT: Create an API key with only READ & RECEIVE scopes. <br />⚠️ Using an API key with WRITE scope could result in loss of funds ⚠️',
         'default' => '',
         'id' => 'blink_api_key',
       ],
+      'ln_address' => [
+        'title' => 'Blink Lightning Address',
+        'type' => 'text',
+        'desc' =>
+          'Your Blink lightning address (non-custodial account type only), e.g. <code>yourname@blink.sv</code>. Payments are received directly to your self-custodial Blink wallet. No API key or Blink dashboard webhook is required.',
+        'default' => '',
+        'placeholder' => 'yourname@blink.sv',
+        'id' => 'blink_ln_address',
+      ],
       'webhook_url' => [
         'title' => 'Webhook Url',
-        'type' => 'custom_markup',
+        'type' => 'blink_custom_markup',
         'markup' =>
           WC()->api_request_url('blink_default') .
-          '<p class="description"> Please use <a target="_blank" href="https://dashboard.blink.sv/callback">Blink dashboard</a> to set it up.</p>',
+          '<p class="description"> Custodial account type only. Please use <a target="_blank" href="https://dashboard.blink.sv/callback">Blink dashboard</a> to set it up, and make sure the callback endpoint is <strong>enabled</strong> (a disabled endpoint silently stops payment notifications and orders will stay in "Pending payment"). Not required for non-custodial (lightning address) accounts.</p>',
         'id' => 'blink_webhook_url',
       ],
       'status' => [
         'title' => 'Setup status',
-        'type' => 'custom_markup',
+        'type' => 'blink_custom_markup',
         'markup' => $setupStatus,
         'id' => 'blink_status',
       ],
@@ -186,7 +217,27 @@ class GlobalSettings extends \WC_Settings_Page {
     Logger::debug('Saving GlobalSettings.');
 
     // nonce validation is not required here because it is done by parent::save()
-    if (!empty($_POST['blink_env']) && !empty($_POST['blink_api_key'])) {
+    $accountType = !empty($_POST['blink_account_type'])
+      ? sanitize_text_field(wp_unslash($_POST['blink_account_type']))
+      : 'custodial';
+
+    if ($accountType === 'non_custodial') {
+      if (!empty($_POST['blink_ln_address'])) {
+        $lnAddress = sanitize_text_field(wp_unslash($_POST['blink_ln_address']));
+
+        if (!BlinkApiHelper::verifyLnAddress($lnAddress)) {
+          $messageException =
+            'Could not verify this Blink lightning address. Please check that it is valid and reachable (format: yourname@blink.sv).';
+          Notice::addNotice('error', $messageException);
+          Logger::debug($messageException, true);
+        }
+      } else {
+        $messageNotConnecting =
+          'Did not try to connect because the Blink lightning address is missing.';
+        Notice::addNotice('warning', $messageNotConnecting);
+        Logger::debug($messageNotConnecting);
+      }
+    } elseif (!empty($_POST['blink_env']) && !empty($_POST['blink_api_key'])) {
       $apiEnv = sanitize_text_field(wp_unslash($_POST['blink_env']));
       $apiKey = sanitize_text_field(wp_unslash($_POST['blink_api_key']));
 
@@ -206,7 +257,7 @@ class GlobalSettings extends \WC_Settings_Page {
     parent::save();
   }
 
-  public function output_custom_markup_field($value) {
+  public static function output_custom_markup_field($value) {
     echo '<tr valign="top">';
     if (!empty($value['title'])) {
       echo '<th scope="row" class="titledesc">' . esc_html($value['title']) . '</th>';

--- a/src/Gateway/BlinkLnGateway.php
+++ b/src/Gateway/BlinkLnGateway.php
@@ -47,6 +47,11 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
     ]);
     add_action('woocommerce_api_' . $this->getId(), [$this, 'processWebhook']);
 
+    // Non-custodial (lightning address) on-site pay page + polling endpoint.
+    add_action('woocommerce_receipt_' . $this->getId(), [$this, 'renderPayPage']);
+    add_action('wp_ajax_blink_check_invoice', [$this, 'ajaxCheckInvoice']);
+    add_action('wp_ajax_nopriv_blink_check_invoice', [$this, 'ajaxCheckInvoice']);
+
     // Supported features.
     $this->supports = ['products'];
   }
@@ -160,6 +165,11 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       throw new \Exception(esc_html($message));
     }
 
+    // Non-custodial (lightning address) accounts are handled on our own pay page.
+    if ($this->apiHelper->isNonCustodial()) {
+      return $this->processPaymentNonCustodial($order);
+    }
+
     // Check for existing invoice and redirect instead.
     if ($this->validInvoiceExists($order)) {
       $existingInvoiceId = $order->get_meta('blink_id');
@@ -193,6 +203,29 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
           urlencode($order->get_checkout_order_received_url()),
       ];
     }
+  }
+
+  /**
+   * Processes a payment for a non-custodial (lightning address) account.
+   *
+   * Creates a BOLT11 invoice via the LNURL flow and sends the buyer to the
+   * on-site order-pay page, where the invoice is displayed and polled.
+   */
+  protected function processPaymentNonCustodial(\WC_Order $order): array {
+    // Reuse an existing, still-valid invoice if present.
+    if (!$order->get_meta('blink_id') || !$order->get_meta('blink_verify_url')) {
+      Logger::debug('Creating non-custodial invoice on Blink');
+      if (!$this->createInvoice($order)) {
+        throw new \Exception(
+          "Can't create the Lightning invoice. Please try again or contact us if the problem persists."
+        );
+      }
+    }
+
+    return [
+      'result' => 'success',
+      'redirect' => $order->get_checkout_payment_url(true),
+    ];
   }
 
   public function process_refund($order_id, $amount = null, $reason = '') {
@@ -303,9 +336,24 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       Logger::debug('Creating invoice with currency: ' . $currency);
       $invoice = $this->apiHelper->createInvoice($amount, $currency, $orderNumber);
 
+      if (!$invoice) {
+        Logger::debug('Invoice creation returned no invoice for order ' . $orderNumber);
+        return null;
+      }
+
       $order->update_meta_data('blink_redirect', $invoice['redirectUrl']);
       $order->update_meta_data('blink_id', $invoice['paymentHash']);
       $order->update_meta_data('blink_payment_request', $invoice['paymentRequest']);
+
+      // Non-custodial invoices carry a LUD-21 verify URL used for polling.
+      if (!empty($invoice['verifyUrl'])) {
+        $order->update_meta_data('blink_account_type', 'non_custodial');
+        $order->update_meta_data('blink_verify_url', $invoice['verifyUrl']);
+      }
+      if (!empty($invoice['satoshis'])) {
+        $order->update_meta_data('blink_satoshis', $invoice['satoshis']);
+      }
+
       $order->save();
 
       return $invoice;
@@ -316,7 +364,7 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
     return null;
   }
 
-  protected function processOrderStatus(\WC_Order $order) {
+  protected function processOrderStatus(\WC_Order $order): string {
     Logger::debug('Updating status for order: ' . $order->get_id());
     // Check if the order is already in a final state, if so do not update it if the orders are protected.
     $protectOrders = get_option('blink_protect_order_status', 'no');
@@ -329,7 +377,7 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
         $note =
           'Webhook received from Blink, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.';
         $order->add_order_note($note);
-        return;
+        return $order->has_status('completed') ? 'PAID' : 'PENDING';
       }
     }
 
@@ -344,7 +392,9 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
         Logger::debug(
           'Trying to fetch existing invoice from Blink for hash ' . $invoiceId
         );
-        $invoice = $this->apiHelper->getInvoice($invoiceId);
+        // Non-custodial orders are settled by polling their LUD-21 verify URL.
+        $verifyUrl = $order->get_meta('blink_verify_url') ?: null;
+        $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl);
         $invoiceStatus = $invoice['status'];
         Logger::debug('Invoice status: ' . $invoiceStatus);
 
@@ -354,18 +404,20 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
             $configuredOrderStates[OrderStates::EXPIRED]
           );
           $order->add_order_note('Invoice expired.');
-          return;
+          return 'EXPIRED';
         }
 
         if ($invoiceStatus === 'PAID') {
           $this->updateWCOrderStatus($order, $configuredOrderStates[OrderStates::PAID]);
           $order->add_order_note('Invoice payment settled.');
-          return;
+          return 'PAID';
         }
       } catch (\Throwable $e) {
         Logger::debug($e->getMessage(), true);
       }
     }
+
+    return 'PENDING';
   }
 
   /**
@@ -378,5 +430,157 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       );
       $order->update_status($status);
     }
+  }
+
+  /**
+   * Renders the on-site pay page for non-custodial (lightning address) orders.
+   *
+   * Displays the BOLT11 invoice as a QR code plus copy button and enqueues the
+   * polling script that watches the LUD-21 verify endpoint for settlement.
+   *
+   * @param int $order_id Order ID (provided by woocommerce_receipt_{id}).
+   */
+  public function renderPayPage($order_id): void {
+    $order = wc_get_order($order_id);
+    if (!$order) {
+      return;
+    }
+
+    // Only handle non-custodial orders here; custodial orders redirect off-site.
+    if ($order->get_meta('blink_account_type') !== 'non_custodial') {
+      return;
+    }
+
+    $paymentRequest = $order->get_meta('blink_payment_request');
+    $paymentHash = $order->get_meta('blink_id');
+    if (!$paymentRequest || !$paymentHash) {
+      echo '<p>' .
+        esc_html__(
+          'Could not load the Lightning invoice for this order. Please contact the store.',
+          'blink-for-woocommerce'
+        ) .
+        '</p>';
+      return;
+    }
+
+    // If the order is already paid (e.g. page reloaded), send to the received page.
+    if ($order->is_paid()) {
+      wp_safe_redirect($order->get_checkout_order_received_url());
+      exit();
+    }
+
+    $this->enqueuePayScripts();
+
+    $lightningUri = 'lightning:' . strtoupper($paymentRequest);
+    $satoshis = (int) $order->get_meta('blink_satoshis');
+
+    wp_localize_script('blink-pay', 'BlinkPay', [
+      'ajaxUrl' => admin_url('admin-ajax.php'),
+      'nonce' => wp_create_nonce('blink-pay-nonce'),
+      'orderId' => $order->get_id(),
+      'orderKey' => $order->get_order_key(),
+      'paymentRequest' => $paymentRequest,
+      'lightningUri' => $lightningUri,
+      'redirectUrl' => $order->get_checkout_order_received_url(),
+      'pollInterval' => 3000,
+    ]);
+    ?>
+    <section class="blink-pay-container" id="blink-pay">
+      <h2><?php echo esc_html__(
+        'Pay with Bitcoin (Lightning)',
+        'blink-for-woocommerce'
+      ); ?></h2>
+      <?php if ($satoshis > 0) { ?>
+        <p class="blink-pay-amount">
+          <?php echo esc_html(
+            sprintf(
+              /* translators: %s: amount in satoshis */
+              __('%s sats', 'blink-for-woocommerce'),
+              number_format_i18n($satoshis)
+            )
+          ); ?>
+        </p>
+      <?php } ?>
+      <div class="blink-pay-qr" id="blink-pay-qr" data-uri="<?php echo esc_attr(
+        $lightningUri
+      ); ?>"></div>
+      <p class="blink-pay-invoice">
+        <code id="blink-pay-bolt11"><?php echo esc_html($paymentRequest); ?></code>
+      </p>
+      <div class="blink-pay-actions">
+        <a class="button" href="<?php echo esc_attr($lightningUri); ?>">
+          <?php echo esc_html__('Open in wallet', 'blink-for-woocommerce'); ?>
+        </a>
+        <button type="button" class="button" id="blink-pay-copy">
+          <?php echo esc_html__('Copy invoice', 'blink-for-woocommerce'); ?>
+        </button>
+      </div>
+      <p class="blink-pay-status" id="blink-pay-status">
+        <?php echo esc_html__('Waiting for payment…', 'blink-for-woocommerce'); ?>
+      </p>
+    </section>
+    <?php
+  }
+
+  /**
+   * Registers and enqueues the pay-page assets (QR generator + poller).
+   */
+  protected function enqueuePayScripts(): void {
+    wp_register_style(
+      'blink-pay',
+      BLINK_PLUGIN_URL . 'assets/css/pay.css',
+      [],
+      BLINK_VERSION
+    );
+    wp_enqueue_style('blink-pay');
+
+    wp_register_script(
+      'blink-qrcode',
+      BLINK_PLUGIN_URL . 'assets/js/frontend/qrcode.min.js',
+      [],
+      BLINK_VERSION,
+      true
+    );
+    wp_register_script(
+      'blink-pay',
+      BLINK_PLUGIN_URL . 'assets/js/frontend/pay.js',
+      ['blink-qrcode'],
+      BLINK_VERSION,
+      true
+    );
+    wp_enqueue_script('blink-qrcode');
+    wp_enqueue_script('blink-pay');
+  }
+
+  /**
+   * AJAX endpoint polled by the pay page to detect settlement of a
+   * non-custodial invoice via its LUD-21 verify URL.
+   */
+  public function ajaxCheckInvoice(): void {
+    check_ajax_referer('blink-pay-nonce', 'nonce');
+
+    $orderId = isset($_POST['order_id']) ? absint($_POST['order_id']) : 0;
+    $orderKey = isset($_POST['order_key'])
+      ? sanitize_text_field(wp_unslash($_POST['order_key']))
+      : '';
+
+    $order = $orderId ? wc_get_order($orderId) : null;
+    if (!$order || !hash_equals($order->get_order_key(), $orderKey)) {
+      wp_send_json_error(['message' => 'Invalid order.'], 403);
+    }
+
+    if ($order->is_paid()) {
+      wp_send_json_success([
+        'status' => 'PAID',
+        'redirect' => $order->get_checkout_order_received_url(),
+      ]);
+    }
+
+    $status = $this->processOrderStatus($order);
+
+    wp_send_json_success([
+      'status' => $status,
+      'redirect' => $status === 'PAID' ? $order->get_checkout_order_received_url() : null,
+    ]);
   }
 }

--- a/src/Gateway/BlinkLnGateway.php
+++ b/src/Gateway/BlinkLnGateway.php
@@ -212,8 +212,11 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
    * on-site order-pay page, where the invoice is displayed and polled.
    */
   protected function processPaymentNonCustodial(\WC_Order $order): array {
-    // Reuse an existing, still-valid invoice if present.
-    if (!$order->get_meta('blink_id') || !$order->get_meta('blink_verify_url')) {
+    // Only reuse an existing invoice if it is still valid (present and not expired
+    // or already gone from the verify endpoint). Otherwise create a fresh one so the
+    // customer never lands on a pay page showing an unpayable, expired QR code.
+    if (!$this->hasReusableNonCustodialInvoice($order)) {
+      $this->clearNonCustodialInvoiceMeta($order);
       Logger::debug('Creating non-custodial invoice on Blink');
       if (!$this->createInvoice($order)) {
         throw new \Exception(
@@ -226,6 +229,57 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       'result' => 'success',
       'redirect' => $order->get_checkout_payment_url(true),
     ];
+  }
+
+  /**
+   * Whether the order already has a non-custodial invoice that can still be paid.
+   */
+  protected function hasReusableNonCustodialInvoice(\WC_Order $order): bool {
+    $invoiceId = $order->get_meta('blink_id');
+    $verifyUrl = $order->get_meta('blink_verify_url');
+    if (!$invoiceId || !$verifyUrl) {
+      return false;
+    }
+
+    // Locally known expiry passed => not reusable.
+    $expiresAt = (int) $order->get_meta('blink_expires_at');
+    if ($expiresAt > 0 && time() >= $expiresAt) {
+      Logger::debug(
+        'Existing non-custodial invoice expired for order ' . $order->get_id()
+      );
+      return false;
+    }
+
+    // Confirm with the verify endpoint: if already paid, keep it (nothing to
+    // recreate); if the server no longer knows it (EXPIRED/not found), recreate.
+    $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl, $expiresAt);
+    $status = is_array($invoice) ? $invoice['status'] ?? 'PENDING' : 'PENDING';
+    if ($status === 'EXPIRED') {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Clears stored non-custodial invoice meta so a fresh invoice can be created.
+   */
+  protected function clearNonCustodialInvoiceMeta(\WC_Order $order): void {
+    foreach (
+      [
+        'blink_id',
+        'blink_verify_url',
+        'blink_payment_request',
+        'blink_created_at',
+        'blink_expires_at',
+        'blink_satoshis',
+        'blink_redirect',
+      ]
+      as $key
+    ) {
+      $order->delete_meta_data($key);
+    }
+    $order->save();
   }
 
   public function process_refund($order_id, $amount = null, $reason = '') {
@@ -353,6 +407,12 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       if (!empty($invoice['satoshis'])) {
         $order->update_meta_data('blink_satoshis', $invoice['satoshis']);
       }
+      if (!empty($invoice['createdAt'])) {
+        $order->update_meta_data('blink_created_at', $invoice['createdAt']);
+      }
+      if (!empty($invoice['expiresAt'])) {
+        $order->update_meta_data('blink_expires_at', $invoice['expiresAt']);
+      }
 
       $order->save();
 
@@ -364,7 +424,10 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
     return null;
   }
 
-  protected function processOrderStatus(\WC_Order $order): string {
+  protected function processOrderStatus(
+    \WC_Order $order,
+    string $context = 'webhook'
+  ): string {
     Logger::debug('Updating status for order: ' . $order->get_id());
     // Check if the order is already in a final state, if so do not update it if the orders are protected.
     $protectOrders = get_option('blink_protect_order_status', 'no');
@@ -374,8 +437,10 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
     if ($protectOrders === 'yes') {
       // Check if the order status is either 'processing' or 'completed'
       if ($order->has_status(['processing', 'completed'])) {
-        $note =
-          'Webhook received from Blink, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.';
+        $note = sprintf(
+          'Blink update received via %s, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.',
+          $context
+        );
         $order->add_order_note($note);
         return $order->has_status('completed') ? 'PAID' : 'PENDING';
       }
@@ -394,7 +459,8 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
         );
         // Non-custodial orders are settled by polling their LUD-21 verify URL.
         $verifyUrl = $order->get_meta('blink_verify_url') ?: null;
-        $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl);
+        $expiresAt = (int) $order->get_meta('blink_expires_at');
+        $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl, $expiresAt);
         $invoiceStatus = $invoice['status'];
         Logger::debug('Invoice status: ' . $invoiceStatus);
 
@@ -403,13 +469,13 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
             $order,
             $configuredOrderStates[OrderStates::EXPIRED]
           );
-          $order->add_order_note('Invoice expired.');
+          $order->add_order_note(sprintf('Invoice expired (via %s).', $context));
           return 'EXPIRED';
         }
 
         if ($invoiceStatus === 'PAID') {
           $this->updateWCOrderStatus($order, $configuredOrderStates[OrderStates::PAID]);
-          $order->add_order_note('Invoice payment settled.');
+          $order->add_order_note(sprintf('Invoice payment settled (via %s).', $context));
           return 'PAID';
         }
       } catch (\Throwable $e) {
@@ -474,6 +540,12 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
     $lightningUri = 'lightning:' . strtoupper($paymentRequest);
     $satoshis = (int) $order->get_meta('blink_satoshis');
 
+    // Absolute polling deadline: the earlier of the invoice expiry and a hard
+    // 30-minute cap, so the browser never polls indefinitely.
+    $expiresAt = (int) $order->get_meta('blink_expires_at');
+    $hardCap = time() + 30 * MINUTE_IN_SECONDS;
+    $deadline = $expiresAt > 0 ? min($expiresAt, $hardCap) : $hardCap;
+
     wp_localize_script('blink-pay', 'BlinkPay', [
       'ajaxUrl' => admin_url('admin-ajax.php'),
       'nonce' => wp_create_nonce('blink-pay-nonce'),
@@ -483,6 +555,8 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       'lightningUri' => $lightningUri,
       'redirectUrl' => $order->get_checkout_order_received_url(),
       'pollInterval' => 3000,
+      // Unix timestamp (seconds) after which the client stops polling.
+      'deadline' => $deadline,
     ]);
     ?>
     <section class="blink-pay-container" id="blink-pay">
@@ -576,7 +650,16 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
       ]);
     }
 
-    $status = $this->processOrderStatus($order);
+    // Rate limit: this endpoint is public (nopriv) and each call triggers an
+    // outbound request to the verify server. Throttle per order so it cannot be
+    // used to amplify traffic against the verify endpoint.
+    $rateLimitKey = 'blink_poll_' . sha1($orderId . '|' . $orderKey);
+    if (get_transient($rateLimitKey)) {
+      wp_send_json_success(['status' => 'PENDING', 'redirect' => null]);
+    }
+    set_transient($rateLimitKey, 1, 2);
+
+    $status = $this->processOrderStatus($order, 'ajax-poll');
 
     wp_send_json_success([
       'status' => $status,

--- a/src/Gateway/BlinkLnGateway.php
+++ b/src/Gateway/BlinkLnGateway.php
@@ -113,14 +113,15 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
    * Get custom gateway icon, if any.
    */
   public function getIcon(): string {
-    $icon = null;
-    if ($mediaId = $this->get_option(self::ICON_MEDIA_OPTION)) {
-      if ($customIcon = wp_get_attachment_image_src($mediaId)[0]) {
-        $icon = $customIcon;
-      }
+    $defaultIcon = BLINK_PLUGIN_URL . 'assets/images/blink-logo.png';
+
+    $mediaId = $this->get_option(self::ICON_MEDIA_OPTION);
+    if (!$mediaId) {
+      return $defaultIcon;
     }
 
-    return $icon ?? BLINK_PLUGIN_URL . 'assets/images/blink-logo.png';
+    $customIcon = wp_get_attachment_image_src($mediaId);
+    return $customIcon[0] ?? $defaultIcon;
   }
 
   public function process_admin_options() {
@@ -160,7 +161,7 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
 
     $order = wc_get_order($order_id);
     if ($order->get_id() === 0) {
-      $message = 'Could not load order id ' . $orderId . ', aborting.';
+      $message = 'Could not load order id ' . $order_id . ', aborting.';
       Logger::debug($message, true);
       throw new \Exception(esc_html($message));
     }
@@ -348,21 +349,17 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
    * @return mixed Returns false if no valid invoice found or the invoice id.
    */
   protected function validInvoiceExists(\WC_Order $order): bool {
-    if ($invoiceId = $order->get_meta('blink_id')) {
-      try {
-        Logger::debug(
-          'Trying to fetch existing invoice from Blink for hash ' . $invoiceId
-        );
-        $invoice = $this->apiHelper->getInvoice($invoiceId);
-        $invalidStates = ['EXPIRED'];
-        if (in_array($invoice['status'], $invalidStates)) {
-          return false;
-        }
+    $invoiceId = $order->get_meta('blink_id');
+    if (!$invoiceId) {
+      return false;
+    }
 
-        return true;
-      } catch (\Throwable $e) {
-        Logger::debug($e->getMessage());
-      }
+    try {
+      Logger::debug('Trying to fetch existing invoice from Blink for hash ' . $invoiceId);
+      $invoice = $this->apiHelper->getInvoice($invoiceId);
+      return $invoice['status'] !== 'EXPIRED';
+    } catch (\Throwable $e) {
+      Logger::debug($e->getMessage());
     }
 
     return false;
@@ -434,53 +431,49 @@ class BlinkLnGateway extends \WC_Payment_Gateway {
 
     Logger::debug('Protect order: ' . $protectOrders);
 
-    if ($protectOrders === 'yes') {
-      // Check if the order status is either 'processing' or 'completed'
-      if ($order->has_status(['processing', 'completed'])) {
-        $note = sprintf(
-          'Blink update received via %s, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.',
-          $context
-        );
-        $order->add_order_note($note);
-        return $order->has_status('completed') ? 'PAID' : 'PENDING';
-      }
+    // If protection is on and the order is already progressing/done, leave it untouched.
+    if ($protectOrders === 'yes' && $order->has_status(['processing', 'completed'])) {
+      $note = sprintf(
+        'Blink update received via %s, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.',
+        $context
+      );
+      $order->add_order_note($note);
+      return $order->has_status('completed') ? 'PAID' : 'PENDING';
     }
 
-    if ($invoiceId = $order->get_meta('blink_id')) {
-      // Get configured order states or fall back to defaults.
-      if (!($configuredOrderStates = get_option('blink_order_states'))) {
-        $configuredOrderStates = (new OrderStates())->getDefaultOrderStateMappings();
+    $invoiceId = $order->get_meta('blink_id');
+    if (!$invoiceId) {
+      return 'PENDING';
+    }
+
+    // Get configured order states or fall back to defaults.
+    if (!($configuredOrderStates = get_option('blink_order_states'))) {
+      $configuredOrderStates = (new OrderStates())->getDefaultOrderStateMappings();
+    }
+    Logger::debug('Configured Order States: ' . implode(', ', $configuredOrderStates));
+
+    try {
+      Logger::debug('Trying to fetch existing invoice from Blink for hash ' . $invoiceId);
+      // Non-custodial orders are settled by polling their LUD-21 verify URL.
+      $verifyUrl = $order->get_meta('blink_verify_url') ?: null;
+      $expiresAt = (int) $order->get_meta('blink_expires_at');
+      $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl, $expiresAt);
+      $invoiceStatus = $invoice['status'];
+      Logger::debug('Invoice status: ' . $invoiceStatus);
+
+      if ($invoiceStatus === 'EXPIRED') {
+        $this->updateWCOrderStatus($order, $configuredOrderStates[OrderStates::EXPIRED]);
+        $order->add_order_note(sprintf('Invoice expired (via %s).', $context));
+        return 'EXPIRED';
       }
-      Logger::debug('Configured Order States: ' . implode(', ', $configuredOrderStates));
 
-      try {
-        Logger::debug(
-          'Trying to fetch existing invoice from Blink for hash ' . $invoiceId
-        );
-        // Non-custodial orders are settled by polling their LUD-21 verify URL.
-        $verifyUrl = $order->get_meta('blink_verify_url') ?: null;
-        $expiresAt = (int) $order->get_meta('blink_expires_at');
-        $invoice = $this->apiHelper->getInvoice($invoiceId, $verifyUrl, $expiresAt);
-        $invoiceStatus = $invoice['status'];
-        Logger::debug('Invoice status: ' . $invoiceStatus);
-
-        if ($invoiceStatus === 'EXPIRED') {
-          $this->updateWCOrderStatus(
-            $order,
-            $configuredOrderStates[OrderStates::EXPIRED]
-          );
-          $order->add_order_note(sprintf('Invoice expired (via %s).', $context));
-          return 'EXPIRED';
-        }
-
-        if ($invoiceStatus === 'PAID') {
-          $this->updateWCOrderStatus($order, $configuredOrderStates[OrderStates::PAID]);
-          $order->add_order_note(sprintf('Invoice payment settled (via %s).', $context));
-          return 'PAID';
-        }
-      } catch (\Throwable $e) {
-        Logger::debug($e->getMessage(), true);
+      if ($invoiceStatus === 'PAID') {
+        $this->updateWCOrderStatus($order, $configuredOrderStates[OrderStates::PAID]);
+        $order->add_order_note(sprintf('Invoice payment settled (via %s).', $context));
+        return 'PAID';
       }
+    } catch (\Throwable $e) {
+      Logger::debug($e->getMessage(), true);
     }
 
     return 'PENDING';

--- a/src/Helpers/BlinkApiHelper.php
+++ b/src/Helpers/BlinkApiHelper.php
@@ -6,20 +6,33 @@ namespace Blink\WC\Helpers;
 
 use Blink\WC\Admin\Notice;
 use Blink\WC\Helpers\BlinkApiClient;
+use Blink\WC\Helpers\BlinkLnurlClient;
 
 class BlinkApiHelper {
   public $configured = false;
   public $env;
   public $apiKey;
   public $walletType;
+  public $accountType = 'custodial';
+  public $lnAddress;
 
   public function __construct() {
     if ($config = self::getConfig()) {
       $this->env = $config['env'];
       $this->apiKey = $config['api_key'];
       $this->walletType = $config['wallet_type'];
+      $this->accountType = $config['account_type'];
+      $this->lnAddress = $config['ln_address'] ?? null;
       $this->configured = true;
     }
+  }
+
+  /**
+   * Whether the currently configured account uses the non-custodial
+   * (lightning address / LNURL) flow.
+   */
+  public function isNonCustodial(): bool {
+    return $this->accountType === 'non_custodial';
   }
 
   public static function getApiUrl(string $env = null): string {
@@ -45,16 +58,37 @@ class BlinkApiHelper {
   }
 
   public static function getConfig(): array {
-    $env = get_option('blink_env');
+    $accountType = get_option('blink_account_type', 'custodial');
+    $env = get_option('blink_env') ?: 'blink';
+    $url = self::getApiUrl($env);
+
+    if ($accountType === 'non_custodial') {
+      $lnAddress = get_option('blink_ln_address');
+      if (!$lnAddress) {
+        return [];
+      }
+
+      return [
+        'account_type' => 'non_custodial',
+        'ln_address' => $lnAddress,
+        'env' => $env,
+        // Kept for currency conversion (public GraphQL query, no auth needed).
+        'api_key' => get_option('blink_api_key') ?: '',
+        // Non-custodial is BTC only for now.
+        'wallet_type' => 'bitcoin',
+        'url' => $url,
+      ];
+    }
+
     $key = get_option('blink_api_key');
     $walletType = get_option('blink_wallet_type');
     if (!$env || !$key || !$walletType) {
       return [];
     }
 
-    $url = self::getApiUrl($env);
     if ($url) {
       return [
+        'account_type' => 'custodial',
         'env' => $env,
         'api_key' => $key,
         'wallet_type' => $walletType,
@@ -63,6 +97,23 @@ class BlinkApiHelper {
     }
 
     return [];
+  }
+
+  /**
+   * Verifies a non-custodial Blink lightning address by resolving its
+   * public LNURL-pay metadata.
+   */
+  public static function verifyLnAddress(string $lnAddress = null): bool {
+    Logger::debug('Start verifyLnAddress');
+    if (!$lnAddress) {
+      Logger::debug('Invalid lightning address');
+      return false;
+    }
+
+    $metadata = BlinkLnurlClient::fetchPayMetadata($lnAddress);
+    $ok = $metadata !== null;
+    Logger::debug('End verifyLnAddress with ' . ($ok ? 'true' : 'false'));
+    return $ok;
   }
 
   public static function verifyApiKey(string $env = null, string $apiKey = null): bool {
@@ -100,8 +151,18 @@ class BlinkApiHelper {
     }
   }
 
-  public function getInvoice(string $paymentHash) {
-    Logger::debug('Start getInvoice for' . $paymentHash);
+  /**
+   * Fetches the current status of an invoice.
+   *
+   * For non-custodial accounts a LUD-21 verify URL is required (there is no
+   * GraphQL status query for lightning-address payments). The returned array
+   * always contains a normalized `status` of PAID | PENDING | EXPIRED.
+   *
+   * @param string      $paymentHash Payment hash of the invoice.
+   * @param string|null $verifyUrl   LUD-21 verify URL (non-custodial only).
+   */
+  public function getInvoice(string $paymentHash, string $verifyUrl = null) {
+    Logger::debug('Start getInvoice for ' . $paymentHash);
     if (!$paymentHash) {
       Logger::debug('Invalid invoice hash');
       return false;
@@ -110,6 +171,10 @@ class BlinkApiHelper {
     if (!$this->configured) {
       Logger::debug('Invalid config', true);
       return false;
+    }
+
+    if ($this->isNonCustodial()) {
+      return $this->getInvoiceNonCustodial($paymentHash, $verifyUrl);
     }
 
     try {
@@ -124,6 +189,38 @@ class BlinkApiHelper {
     }
   }
 
+  /**
+   * Non-custodial invoice status via the LUD-21 verify endpoint.
+   *
+   * Never falsely reports PAID or EXPIRED: transient transport errors and
+   * "not found" responses are reported as PENDING so callers keep polling
+   * rather than dropping a still-payable invoice.
+   */
+  private function getInvoiceNonCustodial(string $paymentHash, string $verifyUrl = null) {
+    if (!$verifyUrl) {
+      Logger::debug('Missing verify url for non-custodial invoice ' . $paymentHash);
+      return ['paymentHash' => $paymentHash, 'status' => 'PENDING'];
+    }
+
+    $verify = BlinkLnurlClient::checkVerify($verifyUrl);
+
+    $status = 'PENDING';
+    if ($verify['settled']) {
+      $status = 'PAID';
+    }
+
+    Logger::debug(
+      'End getInvoice (non-custodial) for ' . $paymentHash . ' status: ' . $status
+    );
+
+    return [
+      'paymentHash' => $paymentHash,
+      'status' => $status,
+      'preimage' => $verify['preimage'],
+      'paymentRequest' => $verify['pr'],
+    ];
+  }
+
   public function createInvoice($amount, $currency, $orderNumber) {
     Logger::debug('Start createInvoice for order ' . $orderNumber);
     if (!$amount || !$currency || !$orderNumber) {
@@ -134,6 +231,10 @@ class BlinkApiHelper {
     if (!$this->configured) {
       Logger::debug('Invalid config', true);
       return null;
+    }
+
+    if ($this->isNonCustodial()) {
+      return $this->createInvoiceNonCustodial($amount, $currency, $orderNumber);
     }
 
     try {
@@ -168,6 +269,87 @@ class BlinkApiHelper {
       return $invoice;
     } catch (\Throwable $e) {
       Logger::debug('Error creating invoice: ' . $e->getMessage(), true);
+      return null;
+    }
+  }
+
+  /**
+   * Creates an invoice for a non-custodial account via the LNURL-pay flow.
+   *
+   * Converts the order's fiat total to satoshis, resolves the merchant's
+   * lightning-address LNURL metadata, then requests a fixed-amount BOLT11
+   * invoice. The order reference is attached as an LUD-12 comment.
+   *
+   * @return array{paymentHash:string,paymentRequest:string,verifyUrl:string,satoshis:int,redirectUrl:null}|null
+   */
+  private function createInvoiceNonCustodial($amount, $currency, $orderNumber) {
+    try {
+      $config = self::getConfig();
+      $lnAddress = $config['ln_address'];
+
+      // Convert the order total to satoshis. This public query needs no auth.
+      $client = new BlinkApiClient($config['url'], $config['api_key']);
+      $conversion = $client->currencyConversionEstimation($amount, $currency);
+      $satoshis = (int) $conversion['btcSatAmount'];
+      if ($satoshis <= 0) {
+        Logger::debug('Non-custodial invoice: non-positive sat amount.');
+        return null;
+      }
+
+      $metadata = BlinkLnurlClient::fetchPayMetadata($lnAddress);
+      if (!$metadata) {
+        Logger::debug('Non-custodial invoice: could not fetch LNURL metadata.');
+        return null;
+      }
+
+      $amountMsat = $satoshis * 1000;
+      $minSendable = (int) $metadata['minSendable'];
+      $maxSendable = (int) $metadata['maxSendable'];
+      if ($minSendable > 0 && $amountMsat < $minSendable) {
+        Logger::debug(
+          'Non-custodial invoice: amount below minSendable (' .
+            $amountMsat .
+            ' < ' .
+            $minSendable .
+            ').'
+        );
+        return null;
+      }
+      if ($maxSendable > 0 && $amountMsat > $maxSendable) {
+        Logger::debug(
+          'Non-custodial invoice: amount above maxSendable (' .
+            $amountMsat .
+            ' > ' .
+            $maxSendable .
+            ').'
+        );
+        return null;
+      }
+
+      $comment = 'GW-' . $orderNumber;
+      $invoice = BlinkLnurlClient::requestInvoice(
+        $metadata['callback'],
+        $amountMsat,
+        $comment
+      );
+      if (!$invoice) {
+        Logger::debug('Non-custodial invoice: LNURL callback did not return an invoice.');
+        return null;
+      }
+
+      Logger::debug('End createInvoice (non-custodial) for ' . $orderNumber);
+
+      return [
+        'paymentHash' => $invoice['paymentHash'],
+        'paymentRequest' => $invoice['paymentRequest'],
+        'verifyUrl' => $invoice['verifyUrl'],
+        'satoshis' => $satoshis,
+        // Non-custodial payments are shown on our own on-site pay page,
+        // so there is no external redirect URL here.
+        'redirectUrl' => null,
+      ];
+    } catch (\Throwable $e) {
+      Logger::debug('Error creating non-custodial invoice: ' . $e->getMessage(), true);
       return null;
     }
   }

--- a/src/Helpers/BlinkApiHelper.php
+++ b/src/Helpers/BlinkApiHelper.php
@@ -53,10 +53,7 @@ class BlinkApiHelper {
       'blink' => 'https://api.blink.sv/graphql',
       'staging' => 'https://api.staging.galoy.io/graphql',
     ];
-    if ($env && isset($urlMapping[$env])) {
-      return $urlMapping[$env];
-    }
-    return $urlMapping['blink'];
+    return $urlMapping[$env] ?? $urlMapping['blink'];
   }
 
   public static function getPayUrl(string $env = null): string {
@@ -64,10 +61,7 @@ class BlinkApiHelper {
       'blink' => 'https://pay.blink.sv',
       'staging' => 'https://pay.staging.galoy.io',
     ];
-    if ($env && isset($urlMapping[$env])) {
-      return $urlMapping[$env];
-    }
-    return $urlMapping['blink'];
+    return $urlMapping[$env] ?? $urlMapping['blink'];
   }
 
   public static function getConfig(): array {
@@ -103,17 +97,13 @@ class BlinkApiHelper {
       return [];
     }
 
-    if ($url) {
-      return [
-        'account_type' => 'custodial',
-        'env' => $env,
-        'api_key' => $key,
-        'wallet_type' => $walletType,
-        'url' => $url,
-      ];
-    }
-
-    return [];
+    return [
+      'account_type' => 'custodial',
+      'env' => $env,
+      'api_key' => $key,
+      'wallet_type' => $walletType,
+      'url' => $url,
+    ];
   }
 
   /**
@@ -140,22 +130,10 @@ class BlinkApiHelper {
       return false;
     }
 
-    $config = self::getConfig();
     $url = self::getApiUrl($env);
 
-    if ($url) {
-      $config['env'] = $env;
-      $config['url'] = $url;
-      $config['api_key'] = $apiKey;
-    }
-
-    if (!$config) {
-      Logger::debug('Invalid config', true);
-      return false;
-    }
-
     try {
-      $client = new BlinkApiClient($config['url'], $config['api_key']);
+      $client = new BlinkApiClient($url, $apiKey);
       $scopes = $client->getAuthorizationScopes();
       $hasReceive = in_array('RECEIVE', $scopes);
       $hasWrite = in_array('WRITE', $scopes);

--- a/src/Helpers/BlinkApiHelper.php
+++ b/src/Helpers/BlinkApiHelper.php
@@ -209,12 +209,13 @@ class BlinkApiHelper {
     $addressDomain = self::lnAddressDomain($this->lnAddress);
     $verify = BlinkLnurlClient::checkVerify($verifyUrl, $addressDomain);
 
+    // A settled invoice is always PAID; an unpaid invoice is only EXPIRED once
+    // past its expiry window.
     $status = 'PENDING';
     if ($verify['settled']) {
-      // A settled invoice is always PAID, even if the expiry window has passed.
       $status = 'PAID';
-    } elseif ($expiresAt > 0 && time() > $expiresAt) {
-      // Only mark EXPIRED once the invoice is past its expiry AND unpaid.
+    }
+    if ($status === 'PENDING' && $expiresAt > 0 && time() > $expiresAt) {
       $status = 'EXPIRED';
     }
 

--- a/src/Helpers/BlinkApiHelper.php
+++ b/src/Helpers/BlinkApiHelper.php
@@ -9,6 +9,9 @@ use Blink\WC\Helpers\BlinkApiClient;
 use Blink\WC\Helpers\BlinkLnurlClient;
 
 class BlinkApiHelper {
+  /** Default non-custodial invoice expiry window, in seconds (60 minutes). */
+  const NON_CUSTODIAL_EXPIRY_SECONDS = 3600;
+
   public $configured = false;
   public $env;
   public $apiKey;
@@ -35,6 +38,16 @@ class BlinkApiHelper {
     return $this->accountType === 'non_custodial';
   }
 
+  /**
+   * Returns the domain part of a lightning address (identifier@domain), or ''.
+   */
+  public static function lnAddressDomain(?string $lnAddress): string {
+    if (!$lnAddress || !str_contains($lnAddress, '@')) {
+      return '';
+    }
+    return trim(strtolower(explode('@', $lnAddress, 2)[1]));
+  }
+
   public static function getApiUrl(string $env = null): string {
     $urlMapping = [
       'blink' => 'https://api.blink.sv/graphql',
@@ -59,6 +72,10 @@ class BlinkApiHelper {
 
   public static function getConfig(): array {
     $accountType = get_option('blink_account_type', 'custodial');
+    // Defense in depth: never trust an out-of-range stored value.
+    if (!in_array($accountType, ['custodial', 'non_custodial'], true)) {
+      $accountType = 'custodial';
+    }
     $env = get_option('blink_env') ?: 'blink';
     $url = self::getApiUrl($env);
 
@@ -160,8 +177,13 @@ class BlinkApiHelper {
    *
    * @param string      $paymentHash Payment hash of the invoice.
    * @param string|null $verifyUrl   LUD-21 verify URL (non-custodial only).
+   * @param int         $expiresAt   Unix timestamp when the invoice expires (non-custodial; 0 = unknown).
    */
-  public function getInvoice(string $paymentHash, string $verifyUrl = null) {
+  public function getInvoice(
+    string $paymentHash,
+    string $verifyUrl = null,
+    int $expiresAt = 0
+  ) {
     Logger::debug('Start getInvoice for ' . $paymentHash);
     if (!$paymentHash) {
       Logger::debug('Invalid invoice hash');
@@ -174,7 +196,7 @@ class BlinkApiHelper {
     }
 
     if ($this->isNonCustodial()) {
-      return $this->getInvoiceNonCustodial($paymentHash, $verifyUrl);
+      return $this->getInvoiceNonCustodial($paymentHash, $verifyUrl, $expiresAt);
     }
 
     try {
@@ -196,17 +218,26 @@ class BlinkApiHelper {
    * "not found" responses are reported as PENDING so callers keep polling
    * rather than dropping a still-payable invoice.
    */
-  private function getInvoiceNonCustodial(string $paymentHash, string $verifyUrl = null) {
+  private function getInvoiceNonCustodial(
+    string $paymentHash,
+    string $verifyUrl = null,
+    int $expiresAt = 0
+  ) {
     if (!$verifyUrl) {
       Logger::debug('Missing verify url for non-custodial invoice ' . $paymentHash);
       return ['paymentHash' => $paymentHash, 'status' => 'PENDING'];
     }
 
-    $verify = BlinkLnurlClient::checkVerify($verifyUrl);
+    $addressDomain = self::lnAddressDomain($this->lnAddress);
+    $verify = BlinkLnurlClient::checkVerify($verifyUrl, $addressDomain);
 
     $status = 'PENDING';
     if ($verify['settled']) {
+      // A settled invoice is always PAID, even if the expiry window has passed.
       $status = 'PAID';
+    } elseif ($expiresAt > 0 && time() > $expiresAt) {
+      // Only mark EXPIRED once the invoice is past its expiry AND unpaid.
+      $status = 'EXPIRED';
     }
 
     Logger::debug(
@@ -326,11 +357,17 @@ class BlinkApiHelper {
         return null;
       }
 
+      $addressDomain = self::lnAddressDomain($lnAddress);
       $comment = 'GW-' . $orderNumber;
+      $expiry = self::NON_CUSTODIAL_EXPIRY_SECONDS;
+      $createdAt = time();
       $invoice = BlinkLnurlClient::requestInvoice(
         $metadata['callback'],
         $amountMsat,
-        $comment
+        $addressDomain,
+        $comment,
+        (int) $metadata['commentAllowed'],
+        $expiry
       );
       if (!$invoice) {
         Logger::debug('Non-custodial invoice: LNURL callback did not return an invoice.');
@@ -344,6 +381,8 @@ class BlinkApiHelper {
         'paymentRequest' => $invoice['paymentRequest'],
         'verifyUrl' => $invoice['verifyUrl'],
         'satoshis' => $satoshis,
+        'createdAt' => $createdAt,
+        'expiresAt' => $createdAt + $expiry,
         // Non-custodial payments are shown on our own on-site pay page,
         // so there is no external redirect URL here.
         'redirectUrl' => null,

--- a/src/Helpers/BlinkLnurlClient.php
+++ b/src/Helpers/BlinkLnurlClient.php
@@ -52,10 +52,119 @@ class BlinkLnurlClient {
   private static function scheme(string $domain): string {
     // Allow plain HTTP only for local development hosts.
     $host = explode(':', $domain, 2)[0];
-    if ($host === 'localhost' || $host === '127.0.0.1') {
+    if (self::isLocalDevHost($host)) {
       return 'http';
     }
     return 'https';
+  }
+
+  private static function isLocalDevHost(string $host): bool {
+    $host = strtolower($host);
+    return $host === 'localhost' || $host === '127.0.0.1' || $host === '[::1]';
+  }
+
+  /**
+   * Returns the registrable base of a host as its last two labels
+   * (e.g. "lnurl.blink.sv" and "blink.sv" both -> "blink.sv"). This is a
+   * pragmatic check (not a full public-suffix list) sufficient to ensure a
+   * callback/verify URL stays within the same organisation's domain as the
+   * configured lightning address.
+   */
+  private static function registrableBase(string $host): string {
+    $host = strtolower(rtrim($host, '.'));
+    $labels = explode('.', $host);
+    if (count($labels) <= 2) {
+      return $host;
+    }
+    return implode('.', array_slice($labels, -2));
+  }
+
+  /**
+   * SSRF guard. A URL returned by an (untrusted) LNURL server is only allowed if:
+   *  - it is a well-formed http(s) URL, and
+   *  - its host shares the same registrable domain as the lightning-address
+   *    domain (so blink.sv may legitimately delegate to lnurl.blink.sv), and
+   *  - it does not resolve to a private/loopback/link-local/reserved IP
+   *    (blocks cloud metadata endpoints such as 169.254.169.254 and intranet
+   *    targets).
+   *
+   * Local development hosts (localhost/127.0.0.1) are allowed only when the
+   * configured address domain is itself a local dev host.
+   */
+  public static function isUrlAllowed(string $url, string $addressDomain): bool {
+    $parts = wp_parse_url($url);
+    if (!$parts || empty($parts['host'])) {
+      Logger::debug('LNURL URL rejected (could not parse): ' . $url);
+      return false;
+    }
+
+    $scheme = strtolower($parts['scheme'] ?? '');
+    if ($scheme !== 'http' && $scheme !== 'https') {
+      Logger::debug('LNURL URL rejected (bad scheme): ' . $url);
+      return false;
+    }
+
+    $host = strtolower($parts['host']);
+    $addressHost = strtolower(explode(':', $addressDomain, 2)[0]);
+
+    // Local dev exception: only if the configured address is itself local.
+    if (self::isLocalDevHost($addressHost)) {
+      return self::isLocalDevHost($host);
+    }
+
+    // Must stay within the same registrable domain as the address.
+    if (self::registrableBase($host) !== self::registrableBase($addressHost)) {
+      Logger::debug(
+        'LNURL URL rejected (host outside address domain): ' .
+          $host .
+          ' vs ' .
+          $addressHost
+      );
+      return false;
+    }
+
+    // Resolve and reject private/reserved IPs (SSRF to intranet/metadata).
+    $ips = self::resolveHost($host);
+    if (empty($ips)) {
+      Logger::debug('LNURL URL rejected (host does not resolve): ' . $host);
+      return false;
+    }
+    foreach ($ips as $ip) {
+      if (!self::isPublicIp($ip)) {
+        Logger::debug('LNURL URL rejected (non-public IP ' . $ip . '): ' . $host);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static function resolveHost(string $host): array {
+    $ips = [];
+    $v4 = @gethostbynamel($host);
+    if (is_array($v4)) {
+      $ips = $v4;
+    }
+    // Best-effort IPv6 resolution.
+    if (function_exists('dns_get_record')) {
+      $aaaa = @dns_get_record($host, DNS_AAAA);
+      if (is_array($aaaa)) {
+        foreach ($aaaa as $rec) {
+          if (!empty($rec['ipv6'])) {
+            $ips[] = $rec['ipv6'];
+          }
+        }
+      }
+    }
+    return $ips;
+  }
+
+  private static function isPublicIp(string $ip): bool {
+    return (bool) filter_var(
+      $ip,
+      FILTER_VALIDATE_IP,
+      FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+    );
   }
 
   private static function httpGet(string $url): ?array {
@@ -63,6 +172,9 @@ class BlinkLnurlClient {
       $client = new \GuzzleHttp\Client(['timeout' => 20]);
       $response = $client->request('GET', $url, [
         'headers' => ['Accept' => 'application/json'],
+        // Legitimate LNURL servers do not redirect; disallowing redirects
+        // prevents a 3xx from bypassing the host/IP SSRF checks.
+        'allow_redirects' => false,
       ]);
       $body = $response->getBody()->getContents();
       $decoded = json_decode($body, true);
@@ -110,25 +222,43 @@ class BlinkLnurlClient {
   /**
    * Requests a BOLT11 invoice from the LNURL-pay callback for a fixed amount.
    *
-   * @param string $callback   LNURL-pay callback URL (from fetchPayMetadata).
-   * @param int    $amountMsat Amount in millisatoshis (must be a whole-sat multiple of 1000).
-   * @param string $comment    Optional LUD-12 comment (order reference), truncated to 255 chars.
+   * @param string $callback       LNURL-pay callback URL (from fetchPayMetadata).
+   * @param int    $amountMsat     Amount in millisatoshis (whole-sat multiple of 1000).
+   * @param string $addressDomain  The lightning-address domain, for the SSRF host check.
+   * @param string $comment        Optional LUD-12 comment (order reference).
+   * @param int    $commentAllowed Max comment length advertised by the server (LUD-12);
+   *                               0 means the server does not accept comments.
+   * @param int    $expiry         Optional requested invoice expiry, in seconds (0 = default).
    *
    * @return array{paymentRequest:string,verifyUrl:string,paymentHash:string}|null
    */
   public static function requestInvoice(
     string $callback,
     int $amountMsat,
-    string $comment = ''
+    string $addressDomain,
+    string $comment = '',
+    int $commentAllowed = 0,
+    int $expiry = 0
   ): ?array {
     if ($amountMsat <= 0 || $amountMsat % 1000 !== 0) {
       Logger::debug('Invalid msat amount for LNURL invoice: ' . $amountMsat);
       return null;
     }
 
+    // SSRF guard: the callback URL comes from an untrusted LNURL response.
+    if (!self::isUrlAllowed($callback, $addressDomain)) {
+      Logger::debug('LNURL callback URL not allowed: ' . $callback);
+      return null;
+    }
+
     $query = ['amount' => $amountMsat];
-    if ($comment !== '') {
-      $query['comment'] = substr($comment, 0, self::MAX_COMMENT_LENGTH);
+    // LUD-12: only send a comment if the server advertises support for it.
+    if ($comment !== '' && $commentAllowed > 0) {
+      $limit = min($commentAllowed, self::MAX_COMMENT_LENGTH);
+      $query['comment'] = substr($comment, 0, $limit);
+    }
+    if ($expiry > 0) {
+      $query['expiry'] = $expiry;
     }
 
     $separator = str_contains($callback, '?') ? '&' : '?';
@@ -149,6 +279,13 @@ class BlinkLnurlClient {
     $verifyUrl = $json['verify'] ?? null;
     if (!$pr || !$verifyUrl) {
       Logger::debug('LNURL invoice response missing pr/verify.');
+      return null;
+    }
+
+    // SSRF guard: the verify URL is persisted and polled repeatedly, so validate
+    // it before it is ever stored.
+    if (!self::isUrlAllowed((string) $verifyUrl, $addressDomain)) {
+      Logger::debug('LNURL verify URL not allowed: ' . $verifyUrl);
       return null;
     }
 
@@ -192,7 +329,10 @@ class BlinkLnurlClient {
    *
    * @return array{settled:bool,preimage:?string,pr:?string,notFound:bool,error:bool}
    */
-  public static function checkVerify(string $verifyUrl): array {
+  public static function checkVerify(
+    string $verifyUrl,
+    string $addressDomain = ''
+  ): array {
     $result = [
       'settled' => false,
       'preimage' => null,
@@ -200,6 +340,14 @@ class BlinkLnurlClient {
       'notFound' => false,
       'error' => false,
     ];
+
+    // Defense in depth: the verify URL is validated at creation time before being
+    // stored, but re-check here since this runs on every (public) poll.
+    if ($addressDomain !== '' && !self::isUrlAllowed($verifyUrl, $addressDomain)) {
+      Logger::debug('Verify URL not allowed at poll time: ' . $verifyUrl);
+      $result['error'] = true;
+      return $result;
+    }
 
     $json = self::httpGet($verifyUrl);
     if ($json === null) {

--- a/src/Helpers/BlinkLnurlClient.php
+++ b/src/Helpers/BlinkLnurlClient.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blink\WC\Helpers;
+
+/**
+ * Minimal client for the public LNURL-pay (LUD-06) + LUD-21 verify flow used by
+ * non-custodial (self-custodial / Spark) Blink accounts.
+ *
+ * Unlike the custodial GraphQL API, this flow requires no API key: a merchant is
+ * identified purely by a lightning address (identifier@domain). Invoices are created
+ * through the LNURL-pay callback and settlement is detected by polling the LUD-21
+ * verify endpoint until `settled` is true.
+ *
+ * The verify endpoint is served from the LNURL callback origin (e.g. lnurl.blink.sv),
+ * which is NOT necessarily the lightning address domain (e.g. blink.sv). This client
+ * always derives the verify URL from the callback response, never by reconstructing it
+ * from the bare address domain.
+ */
+class BlinkLnurlClient {
+  /** Maximum LUD-12 comment length advertised by blink-lnurl-server. */
+  const MAX_COMMENT_LENGTH = 255;
+
+  /**
+   * Splits a lightning address into [identifier, domain].
+   *
+   * @return array{0:string,1:string}|null Null if the address is malformed.
+   */
+  public static function parseLnAddress(string $lnAddress): ?array {
+    $lnAddress = trim($lnAddress);
+    if (!str_contains($lnAddress, '@')) {
+      return null;
+    }
+
+    [$identifier, $domain] = explode('@', $lnAddress, 2);
+    $identifier = trim($identifier);
+    $domain = trim(strtolower($domain));
+
+    if ($identifier === '' || $domain === '') {
+      return null;
+    }
+
+    // Basic sanity: domain must look like a hostname (optionally with port).
+    if (!preg_match('/^[a-z0-9.\-]+(?::\d+)?$/', $domain)) {
+      return null;
+    }
+
+    return [$identifier, $domain];
+  }
+
+  private static function scheme(string $domain): string {
+    // Allow plain HTTP only for local development hosts.
+    $host = explode(':', $domain, 2)[0];
+    if ($host === 'localhost' || $host === '127.0.0.1') {
+      return 'http';
+    }
+    return 'https';
+  }
+
+  private static function httpGet(string $url): ?array {
+    try {
+      $client = new \GuzzleHttp\Client(['timeout' => 20]);
+      $response = $client->request('GET', $url, [
+        'headers' => ['Accept' => 'application/json'],
+      ]);
+      $body = $response->getBody()->getContents();
+      $decoded = json_decode($body, true);
+      return is_array($decoded) ? $decoded : null;
+    } catch (\Throwable $e) {
+      Logger::debug('LNURL GET failed for ' . $url . ': ' . $e->getMessage(), true);
+      return null;
+    }
+  }
+
+  /**
+   * Fetches the LNURL-pay metadata (LUD-06) for a lightning address.
+   *
+   * @return array{callback:string,minSendable:int,maxSendable:int,commentAllowed:int}|null
+   */
+  public static function fetchPayMetadata(string $lnAddress): ?array {
+    $parsed = self::parseLnAddress($lnAddress);
+    if (!$parsed) {
+      Logger::debug('Invalid lightning address: ' . $lnAddress);
+      return null;
+    }
+
+    [$identifier, $domain] = $parsed;
+    $scheme = self::scheme($domain);
+    $url = $scheme . '://' . $domain . '/.well-known/lnurlp/' . rawurlencode($identifier);
+
+    $json = self::httpGet($url);
+    if (!$json) {
+      return null;
+    }
+
+    if (($json['tag'] ?? null) !== 'payRequest' || empty($json['callback'])) {
+      Logger::debug('Not a valid LNURL-pay endpoint for ' . $lnAddress);
+      return null;
+    }
+
+    return [
+      'callback' => (string) $json['callback'],
+      'minSendable' => (int) ($json['minSendable'] ?? 0),
+      'maxSendable' => (int) ($json['maxSendable'] ?? 0),
+      'commentAllowed' => (int) ($json['commentAllowed'] ?? 0),
+    ];
+  }
+
+  /**
+   * Requests a BOLT11 invoice from the LNURL-pay callback for a fixed amount.
+   *
+   * @param string $callback   LNURL-pay callback URL (from fetchPayMetadata).
+   * @param int    $amountMsat Amount in millisatoshis (must be a whole-sat multiple of 1000).
+   * @param string $comment    Optional LUD-12 comment (order reference), truncated to 255 chars.
+   *
+   * @return array{paymentRequest:string,verifyUrl:string,paymentHash:string}|null
+   */
+  public static function requestInvoice(
+    string $callback,
+    int $amountMsat,
+    string $comment = ''
+  ): ?array {
+    if ($amountMsat <= 0 || $amountMsat % 1000 !== 0) {
+      Logger::debug('Invalid msat amount for LNURL invoice: ' . $amountMsat);
+      return null;
+    }
+
+    $query = ['amount' => $amountMsat];
+    if ($comment !== '') {
+      $query['comment'] = substr($comment, 0, self::MAX_COMMENT_LENGTH);
+    }
+
+    $separator = str_contains($callback, '?') ? '&' : '?';
+    $url = $callback . $separator . http_build_query($query);
+
+    $json = self::httpGet($url);
+    if (!$json) {
+      return null;
+    }
+
+    // LNURL errors are returned with HTTP 200 and status ERROR.
+    if (($json['status'] ?? null) === 'ERROR') {
+      Logger::debug('LNURL invoice error: ' . ($json['reason'] ?? 'unknown'));
+      return null;
+    }
+
+    $pr = $json['pr'] ?? null;
+    $verifyUrl = $json['verify'] ?? null;
+    if (!$pr || !$verifyUrl) {
+      Logger::debug('LNURL invoice response missing pr/verify.');
+      return null;
+    }
+
+    $paymentHash = self::paymentHashFromVerifyUrl((string) $verifyUrl);
+    if (!$paymentHash) {
+      Logger::debug('Could not derive payment hash from verify url: ' . $verifyUrl);
+      return null;
+    }
+
+    return [
+      'paymentRequest' => (string) $pr,
+      'verifyUrl' => (string) $verifyUrl,
+      'paymentHash' => $paymentHash,
+    ];
+  }
+
+  /**
+   * Extracts the payment hash from a LUD-21 verify URL of the form
+   * {origin}/verify/{payment_hash}.
+   */
+  public static function paymentHashFromVerifyUrl(string $verifyUrl): ?string {
+    $path = parse_url($verifyUrl, PHP_URL_PATH);
+    if (!$path) {
+      return null;
+    }
+    $segments = explode('/', trim($path, '/'));
+    $hash = end($segments);
+    if (!$hash || !preg_match('/^[a-f0-9]{64}$/i', $hash)) {
+      return null;
+    }
+    return strtolower($hash);
+  }
+
+  /**
+   * Polls the LUD-21 verify endpoint.
+   *
+   * Distinguishes three outcomes so callers never falsely settle or falsely expire:
+   *  - 'settled'  => bool     Payment confirmed when true.
+   *  - 'notFound' => bool     Verify endpoint says the invoice does not exist.
+   *  - 'error'    => bool     Transient transport/parse error; caller should keep polling.
+   *
+   * @return array{settled:bool,preimage:?string,pr:?string,notFound:bool,error:bool}
+   */
+  public static function checkVerify(string $verifyUrl): array {
+    $result = [
+      'settled' => false,
+      'preimage' => null,
+      'pr' => null,
+      'notFound' => false,
+      'error' => false,
+    ];
+
+    $json = self::httpGet($verifyUrl);
+    if ($json === null) {
+      $result['error'] = true;
+      return $result;
+    }
+
+    if (($json['status'] ?? null) === 'ERROR') {
+      // e.g. {"status":"ERROR","reason":"Not found"}
+      $reason = strtolower((string) ($json['reason'] ?? ''));
+      $result['notFound'] = str_contains($reason, 'not found');
+      $result['error'] = !$result['notFound'];
+      return $result;
+    }
+
+    $result['settled'] = (bool) ($json['settled'] ?? false);
+    $result['preimage'] = isset($json['preimage']) ? (string) $json['preimage'] : null;
+    $result['pr'] = isset($json['pr']) ? (string) $json['pr'] : null;
+
+    return $result;
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for **non-custodial (self-custodial / Spark) Blink accounts** via a Lightning address, alongside the existing custodial (API key) flow. Merchants can now receive payments directly to their self-custodial Blink wallet without an API key or a Blink dashboard webhook.

The custodial flow is unchanged.

## How non-custodial works

Non-custodial accounts have no API key and no wallet on `api.blink.sv`. They are reached through the public **LNURL-pay (LUD-06)** + **LUD-21 verify** flow:

1. **Discover:** `GET https://{domain}/.well-known/lnurlp/{identifier}` → read the `callback`, `minSendable`, `maxSendable`.
2. **Create invoice:** `GET {callback}?amount={msat}&comment={order-ref}` → `{ "pr": "lnbc…", "routes": [], "verify": "https://{host}/verify/{payment_hash}" }`. The order reference is sent as an LUD-12 `comment`.
3. **Detect settlement:** poll `GET {verify}` until `settled == true`. There is no dashboard webhook for non-custodial invoices — polling the verify endpoint is the settlement mechanism. The verify host is taken from the callback response, not reconstructed from the address domain.

## Changes

- **Settings:** new **Account Type** selector — *Custodial (API key)* vs *Non-custodial (Lightning address)* — plus a **Blink Lightning Address** field. Connection validation branches per type.
- **`BlinkLnurlClient`** (new): LNURL-pay metadata, invoice creation, and LUD-21 verify polling. Distinguishes settled / not-found / transient errors so it never falsely settles or expires an invoice.
- **`BlinkApiHelper`:** `createInvoice`/`getInvoice` branch per account type. Non-custodial converts the order total to sats, requests a BOLT11 via the LNURL callback, and detects settlement via the verify endpoint.
- **Gateway:** non-custodial orders render the invoice (QR + copy) on an **on-site pay page** and poll a nonce/order-key-protected AJAX endpoint until settled; custodial orders still redirect to the Blink-hosted checkout.
- **Currency:** BTC only for non-custodial in this PR (USD/stablesats via the `+usd` wallet modifier can follow later).

## Incidental fixes (surfaced during live testing)

- **Settings field hook collision:** the plugin used the generic `custom_markup` field type and hooked the global `woocommerce_admin_field_custom_markup` action. When another plugin that uses the same generic type/hook is active (e.g. **BTCPay for WooCommerce**), every plugin's renderer fires for every plugin's fields, so the Blink settings custom rows (Webhook Url, Setup status) rendered **once per active plugin**. Namespaced the type to `blink_custom_markup` (and its hook) and register the field renderers **once** in the plugin bootstrap. This also fixes the symmetric duplication of BTCPay's rows caused by Blink's old generic renderer.
- **Custodial note:** clarified in the settings that the Blink dashboard callback endpoint must be **enabled** — a disabled endpoint silently stops payment notifications and leaves orders in "Pending payment".

## Testing

Validated end-to-end on a live WooCommerce shop with both plugins active:

- **Non-custodial:** placed an order paying `twentyone@blink.sv` → funds landed in the self-custodial wallet and the order was marked settled via verify polling.
- **Custodial:** confirmed unchanged; settlement works once the Blink dashboard callback endpoint is enabled.
- **Settings hook collision:** reproduced the duplicate rows locally with a BTCPay-style generic renderer (2 rows), and confirmed the `blink_custom_markup` fix yields a single row; verified live with both plugins active.
- Lint: `php -l`, `prettier -c`, and `typos` all pass.

## Notes

- BTC only for non-custodial in this PR.
- Bundles a small MIT-licensed QR generator (`assets/js/frontend/qrcode.min.js`) so the on-site pay page renders the invoice QR without third-party network calls.
